### PR TITLE
Bug: Fix inconcistent setting and getting of roles.

### DIFF
--- a/exercise.wwwapi/Models/User.cs
+++ b/exercise.wwwapi/Models/User.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace exercise.wwwapi.Models
 {
-    public enum Roles { teacher, student }
+    public enum Roles { student, teacher }
     [Table("users")]
     public class User
     {


### PR DESCRIPTION
See `exercise.wwwapi/Models/User.cs`.

### How to test?
First, yeet your database and migrations, then create a new migration and update.

Then test the following cases:
* Seeded users with role `teacher` in database should have `role:  1` when getting user by name, and by id.
* Seeded users with role `student` in database should have `role:  0` when getting user by name, and by id.
* Registered users with role set to `role=1`should be viewed in database as a teacher.
* Registered users with role set to `role=0`should be viewed in database as a student.